### PR TITLE
Update docker_remote_api.md

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -29,7 +29,7 @@ later, as these versions have the `--unix-socket` flag available. To
 run `curl` against the daemon on the default socket, use the
 following:
 
-    curl --unix-socket /var/run/docker.sock http:/containers/json
+    curl --unix-socket /var/run/docker.sock http://localhost/containers/json
 
 If you have bound the Docker daemon to a different socket path or TCP
 port, you would reference that in your cURL rather than the


### PR DESCRIPTION
**- What I did**
Changed  docker_remote_api.md
**- How I did it**
 See commit
**- How to verify it**
 See commit
**- Description for the changelog**
Since (I think cURL 7.50.1, atleast > 7.47.1) the URL has been changed for API requests.
See https://github.com/docker/docker/issues/26099#issuecomment-245007539